### PR TITLE
fix(utils): replace itemLinkTo string with correct object

### DIFF
--- a/convert_source_description/default_objects.py
+++ b/convert_source_description/default_objects.py
@@ -36,7 +36,7 @@ defaultDescription: Description = {
 
 defaultContentItem: ContentItem = {
     "item": "",
-    "itemLinkTo": "",
+    "itemLinkTo": {},
     "itemDescription": "",
     "folios": []
 }

--- a/convert_source_description/typed_classes.py
+++ b/convert_source_description/typed_classes.py
@@ -29,10 +29,16 @@ class Folio(TypedDict):
     systemGroups: List[List[System]]
 
 
+class ContentItemLinkTo(TypedDict):
+    """A typed dictionary that represents a content item linkTo section."""
+    complexId: str
+    sheetId: str
+
+
 class ContentItem(TypedDict):
     """A typed dictionary that represents a content item."""
     item: str
-    itemLinkTo: str
+    itemLinkTo: ContentItemLinkTo
     itemDescription: str
     folios: List[Folio]
 

--- a/convert_source_description/utils_helper.py
+++ b/convert_source_description/utils_helper.py
@@ -457,7 +457,7 @@ class ConversionUtilsHelper:
         """
         # Initialize variables
         item_label = ""
-        item_link_to = ""
+        item_link_to = {}
         item_description = ""
         delimiter = "("
 
@@ -475,16 +475,17 @@ class ConversionUtilsHelper:
                 # Extract itemLabel
                 item_label = stripped_para_text[0].strip()
 
+                # Create itemLinkTo dictionary
+                sheet_id = item_label.replace(" ", "_").replace(".", "_").replace("*", "star")
+                complex_id = "".join(sheet_id.split("_")[0:2]).lower()
+
+                item_link_to = {"complexId": complex_id, "sheetId": sheet_id}
+
                 # When there is a slash in the item label,
                 # it means that we probably have multiple sketch items for a row table.
                 # In that case, link to 'SkRT'
                 if item_label.find("/") != -1:
-                    item_link_to = "SkRT"
-                # In all other cases, link to the id created from the itemLabel
-                else:
-                    item_link_to = (
-                        item_label.replace(" ", "_").replace(".", "_").replace("*", "star")
-                    )
+                    item_link_to["sheetId"] = "SkRT"
 
             # Extract itemDescription
             # (re-add delimiter that was removed in the stripping action above


### PR DESCRIPTION
This PR changes the itemLinkTo section of an item in the content of the source description to be provided as object instead of a simple string.

So instead of `"M_217_Sk1"` it will now correctly convert the itemLinkTo to `"{ 'complexId': 'm217', 'sheetId': 'M_217_Sk1' }"` as expected by awg-app.