### PR TITLE
fix(utils): add new block header model for textcritics

### DIFF
--- a/convert_source_description/default_objects.py
+++ b/convert_source_description/default_objects.py
@@ -69,7 +69,12 @@ defaultTextcritics: TextCritics = {
     "label": "",
     "description": [],
     # "rowTable": False,
-    "comments": [],
+    "comments": [
+        {
+            "blockHeader": "",
+            "blockComments": []
+        }
+    ],
     "linkBoxes": []
 }
 

--- a/convert_source_description/typed_classes.py
+++ b/convert_source_description/typed_classes.py
@@ -93,13 +93,19 @@ class TextcriticalComment(TypedDict):
     comment: str
 
 
+class TextcriticalCommentBlock(TypedDict):
+    """A typed dictionary that represents a textcritical comment block."""
+    blockHeader: str
+    blockComments: List[TextcriticalComment]
+
+
 class TextCritics(TypedDict):
     """A typed dictionary that represents a textcritics object."""
     id: str
     label: str
     description: List
     rowTable: bool
-    comments: List[TextcriticalComment]
+    comments: List[TextcriticalCommentBlock]
     linkBoxes: List[LinkBox]
 
 

--- a/convert_source_description/utils.py
+++ b/convert_source_description/utils.py
@@ -102,7 +102,7 @@ class ConversionUtils:
                 comment_text = self.utils_helper.strip_tag_and_clean(columns_in_row[3], 'td')
                 comment['comment'] = self.utils_helper.replace_glyphs(comment_text)
 
-                textcritics['comments'].append(comment)
+                textcritics['comments'][0]['blockComments'].append(comment)
 
             print(
                 f"Appending textcritics for table {table_index + 1}...")


### PR DESCRIPTION
This PR adds the new block header model to the generated textcritics.