### PR TITLE
fix(utils): add missing glyphs

### DIFF
--- a/convert_source_description/utils_helper.py
+++ b/convert_source_description/utils_helper.py
@@ -208,7 +208,23 @@ class ConversionUtilsHelper:
         Returns:
             str: The replaced text.
         """
-        glyphs = ["a", "b", "bb", "#", "x", "f", "ff", "fff", "mf", "mp", "p", "pp", "ppp", "ped"]
+        glyphs = [
+            "a",
+            "b",
+            "bb",
+            "#",
+            "x",
+            "f",
+            "ff",
+            "fff",
+            "mf",
+            "mp",
+            "p",
+            "pp",
+            "ppp",
+            "ped",
+            "sf",
+            "sp"]
         glyph_pattern = '|'.join(re.escape(glyph) for glyph in glyphs)
 
         return re.sub(

--- a/convert_source_description/utils_helper.py
+++ b/convert_source_description/utils_helper.py
@@ -227,10 +227,14 @@ class ConversionUtilsHelper:
             "sp"]
         glyph_pattern = '|'.join(re.escape(glyph) for glyph in glyphs)
 
+        # Match pattern for glyphs in square brackets, but not followed by a hyphen
+        match_pattern = rf'\[({glyph_pattern})\](?!-)'
+
         return re.sub(
-            rf'\[({glyph_pattern})\]',
-            lambda match: f"{{{{ref.getGlyph('{match.group(0)}')}}}}",
-            text)
+            match_pattern,
+            lambda match: f"{{{{ref.getGlyph('{match.group(1)}')}}}}",
+            text
+        )
 
     ############################################
     # Helper function: _get_comment

--- a/convert_source_description/utils_helper.py
+++ b/convert_source_description/utils_helper.py
@@ -208,7 +208,7 @@ class ConversionUtilsHelper:
         Returns:
             str: The replaced text.
         """
-        glyphs = ["a", "b", "bb", "#", "x", "f", "ff", "fff", "p", "pp", "ppp"]
+        glyphs = ["a", "b", "bb", "#", "x", "f", "ff", "fff", "mf", "mp", "p", "pp", "ppp", "ped"]
         glyph_pattern = '|'.join(re.escape(glyph) for glyph in glyphs)
 
         return re.sub(


### PR DESCRIPTION
This PR adds missing glyphs to the converter and improves the glyph matching pattern by excluding cases where a bracket is directly followed by a hyphen (text syllables)