### PR TITLE
fix(utils): fix glyphs

### DIFF
--- a/convert_source_description/utils_helper.py
+++ b/convert_source_description/utils_helper.py
@@ -238,7 +238,7 @@ class ConversionUtilsHelper:
 
         return re.sub(
             match_pattern,
-            lambda match: f"{{{{ref.getGlyph('{match.group(1)}')}}}}",
+            lambda match: f"{{{{ref.getGlyph('{match.group(0)}')}}}}",
             text
         )
 
@@ -611,7 +611,7 @@ class ConversionUtilsHelper:
         return item
 
     ############################################
-    # Helper function: _getItems
+    # Helper function: _get_items
     ############################################
 
     def _get_items(self, paras: List[Tag]) -> List[ContentItem]:

--- a/convert_source_description/utils_helper.py
+++ b/convert_source_description/utils_helper.py
@@ -224,7 +224,13 @@ class ConversionUtilsHelper:
             "ppp",
             "ped",
             "sf",
-            "sp"]
+            "sp",
+            "Achtelnote",
+            "Ganze Note",
+            "Halbe Note",
+            "Sechzehntelnote",
+            "Viertelnote"
+        ]
         glyph_pattern = '|'.join(re.escape(glyph) for glyph in glyphs)
 
         # Match pattern for glyphs in square brackets, but not followed by a hyphen


### PR DESCRIPTION
This PR adds missing glyphs for note values to the converter and fixes an issue where the brackets for the glyphs have not been included in the output.