### PR TITLE
fix(utils): nest all glyphs in classified span

### DIFF
--- a/convert_source_description/utils_helper.py
+++ b/convert_source_description/utils_helper.py
@@ -241,7 +241,7 @@ class ConversionUtilsHelper:
 
         return re.sub(
             match_pattern,
-            lambda match: f"{{{{ref.getGlyph('{match.group(0)}')}}}}",
+            lambda match: f"<span class='glyph'>{{{{ref.getGlyph('{match.group(0)}')}}}}</span>",
             text
         )
 


### PR DESCRIPTION
This PR adds a classified span to the detected glyphs for better global handling.

Supports webern-unibas-ch/awg-app#2064