### PR TITLE
ci(gh-actions): add python 3.14

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
         dir: ${{ fromJSON(needs.detect_changes.outputs.changed_dirs) }}
     
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
         dir: ${{ fromJSON(needs.detect_changes.outputs.changed_dirs) }}
     
     steps:


### PR DESCRIPTION
This PR drops python 3.11 in the CI workflows for newer 3.14.