### PR TITLE
ci(utils): fix name of test job

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,7 +40,7 @@ jobs:
             - 'unify_ids/**'
             - '.github/workflows/pytest.yml'
 
-  lint:
+  test:
     needs: detect_changes
     if: ${{ needs.detect_changes.outputs.changed_dirs != '[]' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes the name of the test job in the pytest.yml.